### PR TITLE
Added justification to the modified allowed error

### DIFF
--- a/Patterns/Multi-device/Multi-device.cpp
+++ b/Patterns/Multi-device/Multi-device.cpp
@@ -332,8 +332,8 @@ int main(int argc, char** argv)
 
     float max_error     = helpers::maxError(h_C, h_Gold);
     float eps           = std::numeric_limits<float>::epsilon();
-    float tolerance     = 10;     // if tests fail try increasing tolerance
-    float allowed_error = eps * tolerance * K * sqrt(K);  // allows for roundoff error 
+    float tolerance     = 10; // if tests fail try increasing tolerance
+    float allowed_error = eps * tolerance * K * sqrt(K); // allows for roundoff error
 
     if(max_error > allowed_error)
     {
@@ -343,7 +343,6 @@ int main(int argc, char** argv)
     {
         std::cout << "PASS";
     }
-
 
     std::cout << ": max_error = " << max_error << std::endl;
 

--- a/Patterns/Multi-device/Multi-device.cpp
+++ b/Patterns/Multi-device/Multi-device.cpp
@@ -330,12 +330,12 @@ int main(int argc, char** argv)
               << K << "," << lda << ", " << ldb << ", " << ldc << ", " << NUM_STREAMS << ", "
               << NUM_DEVICES << std::endl;
 
-    float max_error     = helpers::maxError(h_C, h_Gold);
-    float eps           = std::numeric_limits<float>::epsilon();
-    float tolerance     = 10; // if tests fail try increasing tolerance
-    float allowed_error = eps * tolerance * K * sqrt(K); // allows for roundoff error
+    float max_err     = helpers::maxError(h_C, h_Gold);
+    float eps         = std::numeric_limits<float>::epsilon();
+    float tolerance   = 10; // if tests fail try increasing tolerance
+    float allowed_err = eps * tolerance * K * sqrt(K); // allows for roundoff error
 
-    if(max_error > allowed_error)
+    if(max_err > allowed_err)
     {
         std::cout << "FAIL";
     }
@@ -344,7 +344,7 @@ int main(int argc, char** argv)
         std::cout << "PASS";
     }
 
-    std::cout << ": max_error = " << max_error << std::endl;
+    std::cout << ": max_error = " << max_err << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/Patterns/Multi-device/Multi-device.cpp
+++ b/Patterns/Multi-device/Multi-device.cpp
@@ -330,12 +330,12 @@ int main(int argc, char** argv)
               << K << "," << lda << ", " << ldb << ", " << ldc << ", " << NUM_STREAMS << ", "
               << NUM_DEVICES << std::endl;
 
-    float max_err     = helpers::maxError(h_C, h_Gold);
-    float eps         = std::numeric_limits<float>::epsilon();
-    float tolerance   = 10; // if tests fail try increasing tolerance
-    float allowed_err = eps * tolerance * K * sqrt(K); // allows for roundoff error
+    float max_error     = helpers::maxError(h_C, h_Gold);
+    float eps           = std::numeric_limits<float>::epsilon();
+    float tolerance     = 10; // if tests fail try increasing tolerance
+    float allowed_error = eps * tolerance * K * sqrt(K); // allows for roundoff error
 
-    if(max_err > allowed_err)
+    if(max_error > allowed_error)
     {
         std::cout << "FAIL";
     }
@@ -344,7 +344,7 @@ int main(int argc, char** argv)
         std::cout << "PASS";
     }
 
-    std::cout << ": max_error = " << max_err << std::endl;
+    std::cout << ": max_err = " << max_error << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/Patterns/Multi-device/Multi-device.cpp
+++ b/Patterns/Multi-device/Multi-device.cpp
@@ -330,11 +330,12 @@ int main(int argc, char** argv)
               << K << "," << lda << ", " << ldb << ", " << ldc << ", " << NUM_STREAMS << ", "
               << NUM_DEVICES << std::endl;
 
-    float max_relative_error = helpers::maxError(h_C, h_Gold);
-    float eps                = std::numeric_limits<float>::epsilon();
-    float tolerance          = K * sqrt(K);
+    float max_error     = helpers::maxError(h_C, h_Gold);
+    float eps           = std::numeric_limits<float>::epsilon();
+    float tolerance     = 10;     // if tests fail try increasing tolerance
+    float allowed_error = eps * tolerance * K * sqrt(K);  // allows for roundoff error 
 
-    if(max_relative_error > eps * tolerance)
+    if(max_error > allowed_error)
     {
         std::cout << "FAIL";
     }
@@ -343,7 +344,8 @@ int main(int argc, char** argv)
         std::cout << "PASS";
     }
 
-    std::cout << ": max. relative err. = " << max_relative_error << std::endl;
+
+    std::cout << ": max_error = " << max_error << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/Patterns/Multi-device/README.md
+++ b/Patterns/Multi-device/README.md
@@ -19,3 +19,31 @@ These examples require that you have an installation of rocBLAS on your machine.
     make
     ./Multi-device
  
+## Calculation of allowed_error
+
+Individual entries in the result matrix 'c' are calculated using:
+
+  for(int i = 0; i < M; i++)
+  {
+    for(int j = 0; j < N; j++)
+    {
+      accumulator = 0;
+      for(int k = 0, k < K, k++)
+      {
+        accumulator += a[i + k * lda] * b[k + j * ldb];
+      }
+      c[i + j * ldc] = accumulator;
+    }
+  }
+
+
+With IEEE arithmetic, the allowed roundoff error for each update of the accumulator in the loop is 0.5 * ULP (unit of least precision). When the magnitude of the accumulator is 1 then ULP is approximately equal to eps (epsilon). When the magnitude of the accumulator is |accumulator|, then ULP is approximately
+equal to |accumulator| * eps.
+
+The correctness check requires the calculated result to be close enough to a reference result. The worst-case for the calculated result differing from the reference result would occur if every update of the accumulator in the calculated result rounded up 0.5 ULP and every update of the accumulator in the reference result rounded down 0.5 ULP or vice versa. The matrices a and b have pseudo-random values between 0 and 1. The worst-case for the error between the calculated and reference result would be if every pseudo-random value has the maximum value of 1. This would mean that the accumulator would have values 1, 2, 3, ... K.
+
+If we have both the worst cases above, then the allowable error is approximately:
+eps * (1 + 2 + 3 + ... + K) = eps * 0.5 * K * (K+1)
+The statistical probability that all 2 * K pseudo-random values in matrices a and b will be equal to 1 is small. The statistical probability that the calculated result will always round up and the reference result will always round down (or vice versa) is small. In place of the K in the above allowable error, the statistical argument suggests we use sqrt(K). Because this is a non-rigorous argument, in place of 0.5 we use a tolerance of 10. Thus, we allow an error between the calculated and reference result of:
+ eps * sqrt(K) * K * 10.
+


### PR DESCRIPTION
Made few changes in the code to replace 'max_relative_error' to 'max_error' and added 'allowed error' = eps * 10 * K * sqrt(K). Added Justification to the calculation of 'allowed error' in README. This is a follow up to the [PR](https://github.com/ROCmSoftwarePlatform/rocBLAS-Examples/pull/45).