### PR TITLE
add ROCBLAS_PATH to Makefiles

### DIFF
--- a/Extensions/gemm_ex_bf16_r/Makefile
+++ b/Extensions/gemm_ex_bf16_r/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -46,13 +46,13 @@ CXX=$(HIPCXX)
 OPT = -g -Wall 
 # removing these temporarily as hipcc can not process
 # -Ofast -march=native 
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Extensions/gemm_ex_f16_r/Makefile
+++ b/Extensions/gemm_ex_f16_r/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -46,13 +46,13 @@ CXX=$(HIPCXX)
 OPT = -g -Wall 
 # removing these temporarily as hipcc can not process
 # -Ofast -march=native 
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Extensions/gemm_ex_f32_r/Makefile
+++ b/Extensions/gemm_ex_f32_r/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Extensions/gemm_ex_i8_i32_r/Makefile
+++ b/Extensions/gemm_ex_i8_i32_r/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Languages/C/Makefile
+++ b/Languages/C/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -43,13 +43,13 @@ CC=gcc
 # uncomment to use hip compiler
 #CC=$(HIPCXX)
 OPT = -ggdb -O0 -march=native -Wall
-INC = -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include -I../../common
+INC = -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include -I../../common
 CCFLAGS = -std=c11 $(INC) $(OPT) 
 ifneq ($(CC),$(HIPCXX))
 	CCFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lc
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Languages/Fortran/Makefile
+++ b/Languages/Fortran/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -41,13 +41,13 @@ OBJECTS = $(patsubst %.f90, %.o, $(SOURCES))
 
 CC=gfortran
 OPT = -ggdb -O0 -march=native -Wall -Wno-c-binding-type
-INC = -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include -I../../common
+INC = -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include -I../../common
 FFLAGS = $(INC) $(OPT) 
 ifneq ($(CC),$(HIPCXX))
 	FFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Languages/HIP/Makefile
+++ b/Languages/HIP/Makefile
@@ -12,7 +12,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -21,13 +21,13 @@ OBJECTS = $(patsubst %.cpp, %.o, $(SOURCES))
 
 CXX=$(HIPCXX) # needed for hip kernel compilation
 OPT = -ggdb -O0 -march=native -Wall
-INC = -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include -I../../common
+INC = -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include -I../../common
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CCFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__ 
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-1/axpy/Makefile
+++ b/Level-1/axpy/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-1/dot/Makefile
+++ b/Level-1/dot/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-1/nrm2/Makefile
+++ b/Level-1/nrm2/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-1/scal/Makefile
+++ b/Level-1/scal/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-1/swap/Makefile
+++ b/Level-1/swap/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-2/gemv/Makefile
+++ b/Level-2/gemv/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-2/her/Makefile
+++ b/Level-2/her/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-3/gemm/Makefile
+++ b/Level-3/gemm/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Level-3/gemm_strided_batched/Makefile
+++ b/Level-3/gemm_strided_batched/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Patterns/Multi-device/Makefile
+++ b/Patterns/Multi-device/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++ -fopenmp
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT) 
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif

--- a/Patterns/Multi-stream/Makefile
+++ b/Patterns/Multi-stream/Makefile
@@ -32,7 +32,7 @@ endif
 HIPCXX=$(HIP_PATH)/bin/hipcc
 
 ifeq (,$(ROCBLAS_PATH))
-        ROCBLAS_PATH= $(wildcard /opt/rocm/rocblas)
+        ROCBLAS_PATH= $(wildcard /opt/rocm/include)
 endif
 
 EXE = $(shell basename $(CURDIR))
@@ -44,13 +44,13 @@ CXX=g++ -fopenmp
 # uncomment to use hip compiler
 #CXX=$(HIPCXX)
 OPT = -g -Ofast -march=native -Wall
-INC = -I$(COMMON_PATH) -isystem$(ROCM_PATH)/include -isystem$(ROCBLAS_PATH)/include
+INC = -I$(COMMON_PATH) -isystem$(ROCBLAS_PATH)/include -isystem$(ROCM_PATH)/include 
 CXXFLAGS = -std=c++14 $(INC) $(OPT)
 ifneq ($(CXX),$(HIPCXX))
 	CXXFLAGS += -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_HCC__
 endif
 
-LDFLAGS=-L$(ROCM_PATH)/lib -L$(ROCBLAS_PATH)/lib -lrocblas -Wl,-rpath=$(ROCM_PATH)/lib -Wl,-rpath=$(ROCBLAS_PATH)/lib -lm -lpthread -lstdc++
+LDFLAGS=-L$(ROCBLAS_PATH)/lib -L$(ROCM_PATH)/lib -lrocblas -Wl,-rpath=$(ROCBLAS_PATH)/lib -Wl,-rpath=$(ROCM_PATH)/lib -lm -lpthread -lstdc++
 ifneq ($(CXX),$(HIPCXX))
 	LDFLAGS += -lamdhip64
 endif


### PR DESCRIPTION
- README files have line 
``` If rocBLAS is not installed you can set the environment variable ROCBLAS_PATH to point to the location of your rocblas build. ```
- The additions to Makefile provide for this functionality.